### PR TITLE
Add community infrastructure for contributor readiness

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Default owners for everything
+* @AviOfLagos
+
+# Server core
+apps/server/src/server.js @AviOfLagos
+apps/server/src/lib/ @AviOfLagos
+
+# Dashboard
+apps/dashboard/ @AviOfLagos
+
+# CI and project config
+.github/ @AviOfLagos
+turbo.json @AviOfLagos
+pnpm-workspace.yaml @AviOfLagos

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ apps/server/logs.txt
 .DS_Store
 *.log
 
-# Docs (generated)
-docs/
+# Note: docs/ is tracked — contains roadmap, strategy, and backlog
 
 # Note: .github/ directory IS tracked (contains workflows and templates)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,84 +4,94 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Is
 
-OpenAdapter is a local Express server that bridges claude.ai's web interface into an OpenAI-compatible API using Playwright. It launches a headful Chromium browser, automates the Claude web UI via DOM manipulation, and exposes `POST /v1/chat/completions` at `http://127.0.0.1:3000`. There is also a standalone CLI tool (`adapter.js`) for one-off prompts.
+OpenAdapter is a monorepo containing two apps:
+
+1. **Adapter Server** (`apps/server/`) — A local Express server that bridges claude.ai's web interface into an OpenAI-compatible API using Playwright. It launches a headful Chromium browser, automates the Claude web UI via DOM manipulation, and exposes `POST /v1/chat/completions` at `http://127.0.0.1:3001`. Includes a standalone CLI tool (`adapter.js`) and a remote management API (8 admin endpoints).
+
+2. **Dashboard** (`apps/dashboard/`) — A Next.js 16 management interface with 4 tabs: Chat, Activities, Logs, Settings. The monitoring tabs connect to the adapter server's management API. The chat tab currently uses Vercel AI Gateway (not yet wired to OpenAdapter).
+
+## Monorepo Setup
+
+- **Package manager:** pnpm with workspaces
+- **Build tool:** Turborepo
+- **Workspace config:** `pnpm-workspace.yaml` (apps/*, packages/*)
 
 ## Commands
 
 ```bash
 # Setup
-npm install                        # Install dependencies
-npx playwright install chromium    # Install Playwright's bundled Chromium
+pnpm install                       # Install all dependencies
+cd apps/server && npx playwright install chromium  # Install browser
 
-# Running the server
-npm start                          # Run unit tests first, then start server (recommended)
-npm run dev                        # Start server directly, skipping tests
-node server.js                     # Alternative to npm run dev
+# Running (from monorepo root)
+pnpm dev                           # Start both server (:3001) and dashboard (:3000)
+pnpm dev:server                    # Server only
+pnpm dev:dashboard                 # Dashboard only
 
-# Testing (uses Node's built-in test runner)
-npm test                           # Run all tests (unit + integration)
-npm run test:unit                  # Unit tests only (no server needed)
-npm run test:integration           # Integration tests (requires running server)
+# Testing
+pnpm test                          # Run all tests via Turborepo
+pnpm test:unit                     # Unit tests only (no server needed)
+pnpm test:integration              # Integration tests (requires running server)
 
-# CLI tool
-node adapter.js "your prompt"      # Single prompt, exits after response
+# Building
+pnpm build                         # Build all apps
 
-# Remote management (optional API key auth via ADMIN_API_KEY env var)
-curl http://127.0.0.1:3000/admin/health           # Health check
-curl -X POST http://127.0.0.1:3000/admin/session/restart  # Restart browser
+# From apps/server/ directly
+npm start                          # Run unit tests then start server
+npm run dev                        # Start server directly
+npm run test:unit                  # Server unit tests
+node src/adapter.js "your prompt"  # CLI tool
+
+# Remote management
+curl http://127.0.0.1:3001/admin/health           # Health check
+curl -X POST http://127.0.0.1:3001/admin/session/restart  # Restart browser
 ```
 
-No linter is configured.
+No linter is configured for the server. The dashboard uses Next.js's built-in linting.
 
 ## Architecture
 
+### Server (`apps/server/`)
+
 **Request flow:** Client sends OpenAI-format POST → `server.js` extracts prompt/files via `extractPayload()` → gets or recovers a Playwright page via `sessionManager.getOrInitPage()` → types prompt into Claude's contenteditable input → polls DOM for response via `waitForCompletion()` → converts HTML to Markdown via `htmlToMd.htmlToMarkdown()` (runs in-browser via `page.evaluate()`) → checks for rate limits via `rateLimiter.checkRateLimit()` → returns OpenAI-shaped JSON or SSE stream.
 
-**Key modules:**
-- `server.js` — Express server, chat completions endpoint + management API, handles streaming/non-streaming, file uploads (base64 → temp file → Playwright file input), system context deduplication (MD5 hash), large prompt conversion to file attachments (>15k chars)
-- `adapter.js` — Standalone CLI tool with its own browser lifecycle. Duplicates selector chains and DOM helpers from server.js (not shared)
-- `lib/sessionManager.js` — Browser lifecycle with multi-tier recovery (L0: JS eval probe → L1: reload → L2: navigate to /new → L3: full browser restart → L4: fatal/503). Exports shared mutable `state` object
-- `lib/htmlToMd.js` — Self-contained DOM→Markdown converter. **Must remain free of Node.js globals** because it's serialized and executed inside the browser via `page.evaluate()`
-- `lib/rateLimiter.js` — Regex-based rate limit detection from DOM elements and response text, returns OpenAI-format 429 responses
-- `lib/managementController.js` — Remote management API (health checks, session control, log access, stats tracking). Optional authentication via `ADMIN_API_KEY` environment variable
+**Key modules (all in `apps/server/src/`):**
+- `server.js` — Express server, chat completions endpoint + management API, handles streaming/non-streaming, file uploads, system context deduplication
+- `adapter.js` — Standalone CLI tool with its own browser lifecycle
+- `lib/sessionManager.js` — Browser lifecycle with multi-tier recovery (L0-L4)
+- `lib/htmlToMd.js` — DOM-to-Markdown converter. **Must remain free of Node.js globals** (runs in-browser via `page.evaluate()`)
+- `lib/rateLimiter.js` — Rate limit detection from DOM and response text
+- `lib/extractPayload.js` — OpenAI message parser and file handler
+- `lib/managementController.js` — Remote management API (health, session control, logs, config)
 
-**Selector chains:** Both `server.js` and `adapter.js` define `SELECTOR_CHAINS` objects with fallback CSS selectors for Claude's UI elements (promptInput, sendButton, stopButton, responseBlocks, fileInput). These break when Claude updates their DOM and need manual inspection to fix.
+**Tests (in `apps/server/tests/`):**
+- Unit tests: `extractPayload`, `htmlToMd`, `rateLimiter`, `toolCallParser` — 61 tests, no server needed
+- Integration tests: HTTP endpoint validation against a live server
 
-**Concurrency:** The server handles one request at a time (`isGenerating` flag). Concurrent requests get 429.
+### Dashboard (`apps/dashboard/`)
 
-**Browser profile:** `.browser-profile/` stores persistent Chromium session data so the user only logs in once. This directory is gitignored.
+**Stack:** Next.js 16, React 19, TypeScript, Tailwind CSS v4, shadcn/ui, Vercel AI SDK v6
 
-**Configuration values** (hardcoded in source files):
-- `PORT`: 3000 (server listen port)
-- `MAX_TIMEOUT_MS`: 180000ms (3 min) in server.js, 120000ms (2 min) in adapter.js — hard timeout waiting for Claude's response
-- `STABLE_INTERVAL_MS`: 30000ms (30 sec) in server.js, 3000ms (3 sec) in adapter.js — content-unchanged threshold to consider response complete
-- `POLL_MS`: 500ms — DOM polling interval
-- `SESSION_TIMEOUT_MS`: 3600000ms (1 hr) — inactivity before starting a new conversation
-- Large prompt threshold: 15000 chars — prompts exceeding this are converted to file attachments
+**Key files:**
+- `lib/openadapter-client.ts` — Type-safe API client for the adapter server
+- `components/dashboard-tabs.tsx` — Tab navigation
+- `components/server-health-monitor.tsx` — Real-time health metrics
+- `components/logs-viewer.tsx` — Log viewer with search/filter
+- `components/server-settings.tsx` — Session controls
 
 ## Important Constraints
 
 - The browser **must run headful** (Cloudflare blocks headless Chromium)
-- `htmlToMd.js`'s `htmlToMarkdown` function runs inside the browser — no `require()`, no Node APIs
-- System context is deduplicated across requests using MD5 hashing stored in `sessionState.lastSystemContextHash`
-- HTTP server timeouts are set to 10 minutes (600s) to support long Claude generations
-- Token counts in responses are estimates (char length / 4), not real tokenization
-
-## Testing
-
-The project uses Node's built-in test runner (`node:test`). Tests are in `tests/`:
-- **Unit tests** (`tests/unit/`): Test `extractPayload`, `htmlToMd`, and `rateLimiter` modules in isolation. No server needed.
-- **Integration tests** (`tests/integration/`): Validate the HTTP endpoint against a live server. Requires the server to be running.
-
-`npm start` runs unit tests before starting the server. Unit tests are fast and catch regressions in core modules.
+- `htmlToMd.js` runs inside the browser — no `require()`, no Node APIs
+- System context is deduplicated via MD5 hash in `sessionState.lastSystemContextHash`
+- Server port is **3001** (dashboard uses 3000)
+- Token counts in responses are estimates (char length / 4)
+- Server code is CommonJS (`require`/`module.exports`); dashboard is TypeScript/ESM
 
 ## Coding Standards
 
-When modifying code, follow these conventions:
-
-- **Logging**: Use `appendLog()` in server code (writes to both console and `logs.txt`). Prefix log lines with `[moduleName]` for traceability (e.g., `[server]`, `[sessionManager]`)
-- **Async**: Use `async/await` over raw promises
-- **Variables**: Use `const`/`let`, never `var`
-- **Selectors**: Add new selectors to `SELECTOR_CHAINS` objects rather than hardcoding them inline. Update both `server.js` and `adapter.js` if both need the same selector
-- **Error responses**: Return OpenAI-shaped error objects with appropriate HTTP status codes (see `CONTRIBUTING.md` for format)
-- **Functions**: Keep functions focused. If adding significant logic, put it in a new file under `lib/`
+- **Server:** CommonJS, `const`/`let` (no `var`), `async/await`, `appendLog()` for logging with `[moduleName]` prefixes
+- **Dashboard:** TypeScript, React Server Components, shadcn/ui conventions
+- **Selectors:** Always in `SELECTOR_CHAINS` objects, never hardcoded inline
+- **Error responses:** OpenAI-shaped error objects with appropriate HTTP status codes
+- **New logic:** Put in a new file under `lib/`, keep functions focused

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making participation in this project a welcoming experience for everyone, regardless of background or identity.
+
+## Our Standards
+
+**Positive behavior includes:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+**Unacceptable behavior includes:**
+
+- Trolling, insulting/derogatory comments, and personal attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Scope
+
+This Code of Conduct applies within all project spaces — issues, pull requests, discussions, and any other communication channels associated with OpenAdapter.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by opening an issue or contacting the maintainers. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,178 +1,215 @@
 # Contributing to OpenAdapter
 
-Thanks for your interest in contributing! This guide will help you understand the codebase and get productive quickly.
+Thanks for your interest in contributing! This guide covers everything you need to get productive.
 
-## Getting Started
+## Quick Start
 
-1. Fork and clone the repo
-2. Install dependencies:
-   ```bash
-   npm install
-   npx playwright install chromium
-   ```
-3. Start the server (runs tests first, then starts):
-   ```bash
-   npm start
-   ```
-4. On first run, a Chromium window opens — log into `claude.ai` manually. Your session persists in `.browser-profile/`.
-5. Test with:
-   ```bash
-   curl http://127.0.0.1:3000/v1/chat/completions \
-     -H "Content-Type: application/json" \
-     -d '{"messages": [{"role": "user", "content": "Hello"}]}'
-   ```
+```bash
+# 1. Fork and clone
+git clone https://github.com/<your-username>/openAdapter.git
+cd openAdapter
 
-## Codebase Overview
+# 2. Install dependencies (uses pnpm)
+pnpm install
 
-```
-open-adapter/
-├── server.js               # Express API server — main entry point
-├── adapter.js              # Standalone CLI tool (single prompt, exits)
-├── lib/
-│   ├── sessionManager.js   # Browser lifecycle & multi-tier recovery
-│   ├── extractPayload.js   # OpenAI message parser & file attachment handler
-│   ├── htmlToMd.js         # HTML-to-Markdown converter (runs in-browser)
-│   └── rateLimiter.js      # Detects Claude rate limits from DOM & text
-├── tests/
-│   ├── unit/               # Unit tests (extractPayload, htmlToMd, rateLimiter)
-│   └── integration/        # Integration tests (HTTP endpoint validation)
-├── .browser-profile/       # Persistent Chromium session (gitignored)
-├── temp_uploads/           # Temporary file attachments (auto-cleaned)
-└── logs.txt                # Request/response logs (runtime)
+# 3. Install Playwright browser
+cd apps/server && npx playwright install chromium && cd ../..
+
+# 4. Start development
+pnpm dev          # Starts both server (:3001) and dashboard (:3000)
+# Or just the server:
+pnpm dev:server
 ```
 
-### How a request flows
+On first run, a Chromium window opens — log into `claude.ai` manually once. Your session persists in `.browser-profile/`.
 
-1. **`server.js`** receives a `POST /v1/chat/completions` request in OpenAI format
+## Monorepo Structure
+
+This is a **pnpm + Turborepo** monorepo with two apps:
+
+```
+openAdapter/
+├── apps/
+│   ├── server/              # @openadapter/server — Express API bridge
+│   │   ├── src/
+│   │   │   ├── server.js    # Main server + OpenAI endpoint
+│   │   │   ├── adapter.js   # Standalone CLI tool
+│   │   │   └── lib/         # Core modules
+│   │   ├── tests/
+│   │   │   ├── unit/        # 61 unit tests (node:test)
+│   │   │   └── integration/ # HTTP endpoint tests
+│   │   └── package.json
+│   │
+│   └── dashboard/           # @openadapter/dashboard — Next.js management UI
+│       ├── app/             # Routes: chat, activities, logs, settings
+│       ├── components/      # React + shadcn/ui components
+│       ├── lib/             # API client, utilities
+│       └── package.json
+│
+├── packages/                # Shared packages (planned, currently empty)
+├── turbo.json               # Build pipeline config
+└── pnpm-workspace.yaml      # Workspace definition
+```
+
+### Running Commands
+
+```bash
+# From monorepo root
+pnpm dev                   # Start both apps
+pnpm dev:server            # Server only
+pnpm dev:dashboard         # Dashboard only
+pnpm test:unit             # Unit tests (fast, no server needed)
+pnpm test                  # All tests
+pnpm build                 # Build everything
+```
+
+### Working in a Single App
+
+```bash
+cd apps/server
+npm run test:unit          # Server unit tests
+npm run dev                # Server only
+
+cd apps/dashboard
+pnpm dev                   # Dashboard dev server
+pnpm build                 # Production build
+```
+
+## How the Adapter Server Works
+
+### Request Flow
+
+1. **`server.js`** receives `POST /v1/chat/completions` in OpenAI format
 2. **`extractPayload()`** parses messages — extracts text, decodes base64 images/files, deduplicates system context
-3. **`sessionManager.getOrInitPage()`** returns a live Playwright page (launching the browser on first call, recovering if needed)
-4. The prompt is typed into Claude's chat input and submitted via DOM selectors
-5. **`waitForCompletion()`** polls the DOM for Claude's response, calling `htmlToMd.htmlToMarkdown()` to convert HTML to Markdown
+3. **`sessionManager.getOrInitPage()`** returns a live Playwright page (launching browser on first call, recovering if needed)
+4. The prompt is typed into Claude's chat input via DOM selectors
+5. **`waitForCompletion()`** polls the DOM, calling `htmlToMd.htmlToMarkdown()` to convert HTML to Markdown
 6. If streaming is enabled, chunks are sent as SSE events during polling
 7. **`rateLimiter.checkRateLimit()`** inspects the response for rate-limit indicators
 8. The response is returned in OpenAI chat completion format
 
-### Key architectural decisions
+### Key Architectural Decisions
 
-**Selector chains** — All DOM interaction goes through `SELECTOR_CHAINS` at the top of `server.js` (and `adapter.js`). Each key maps to an ordered list of CSS selectors tried in sequence. This provides resilience when Claude's UI changes — only the first matching selector needs to work.
+**Selector chains** — All DOM interaction goes through `SELECTOR_CHAINS` objects with ordered fallback CSS selectors. When Claude updates their UI, only the selectors need updating.
 
-**Single-request gating** — The `isGenerating` flag ensures only one request runs at a time. This is intentional: we control a single browser tab, so concurrent DOM manipulation would corrupt state.
+**Single-request gating** — The `isGenerating` flag ensures one request at a time. We control a single browser tab, so concurrent DOM manipulation would corrupt state.
 
-**In-browser Markdown conversion** — `htmlToMd.js` exports a function that is serialized and executed inside Chromium via `page.evaluate()`. This means:
-- It **cannot** use `require()`, `import`, or any Node.js APIs
-- It **cannot** reference variables outside its own function scope
-- It receives a DOM `Element` as its argument and returns a string
-- If you modify it, test by running a real request — unit testing requires a browser context
+**In-browser Markdown conversion** — `htmlToMd.js` is serialized and executed inside Chromium via `page.evaluate()`. It **cannot** use `require()`, `import`, or any Node.js APIs.
 
-**Session recovery tiers** — `sessionManager.js` implements escalating recovery:
+**Session recovery tiers** — `sessionManager.js` implements escalating recovery (L0: liveness check → L1: reload → L2: navigate to /new → L3: restart browser → L4: return 503).
 
-| Level | Action | When it's tried |
-|-------|--------|-----------------|
-| L0 | JS eval liveness check | Every request (health gate) |
-| L1 | Page reload | Page is unresponsive |
-| L2 | Navigate to `claude.ai/new` | Reload didn't help |
-| L3 | Kill browser + relaunch | Navigation failed |
-| L4 | Return null (503 to client) | Everything failed |
-
-**System context deduplication** — System messages are hashed (MD5). If the hash matches the previous request, the system context isn't re-uploaded as a file attachment, saving time and avoiding redundant context.
+**System context deduplication** — System messages are MD5-hashed. If unchanged from the last request, the context isn't re-uploaded.
 
 ## Making Changes
 
-### Updating selectors
+### PR Workflow
 
-Claude's UI changes periodically. When it does:
+1. Create a branch from `main` (or the relevant feature branch)
+2. Make your changes
+3. Run tests: `pnpm test:unit`
+4. Push and open a PR
+5. CI will run lint and unit tests automatically
 
-1. Open `claude.ai` in Chrome
-2. Right-click the element (input box, send button, etc.) and Inspect (F12)
-3. Find a stable selector (prefer `data-testid`, `aria-label`, or semantic attributes over class names)
-4. Add your selector to the appropriate array in `SELECTOR_CHAINS` — put the most reliable one first
-5. Update both `server.js` and `adapter.js` if both use the same chain
+### Updating Selectors
 
-### Adding new DOM interactions
+Claude's UI changes periodically. When elements break:
 
-Use the existing helper functions:
+1. Open `claude.ai` in Chrome DevTools (F12)
+2. Find a stable selector (prefer `data-testid`, `aria-label` over class names)
+3. Add to the `SELECTOR_CHAINS` array in both `server.js` and `adapter.js` — most reliable selector first
+4. Test with a real request
 
-```js
-// Find a single element (tries each selector in order)
-const { el, selector } = await findElement(page, 'chainKey');
-
-// Find all matching elements
-const { els, selector } = await findAllElements(page, 'chainKey');
-
-// Wait for any selector in the chain to appear
-await waitForAny(page, 'chainKey', { timeout: 15000, state: 'visible' });
-```
-
-Add your new selectors to the `SELECTOR_CHAINS` object rather than hardcoding them inline.
-
-### Modifying htmlToMd.js
-
-Remember this function runs **inside Chromium**, not in Node.js. To test changes:
-
-1. Start the server
-2. Send a request that triggers the formatting you changed (tables, code blocks, etc.)
-3. Check the response content and `logs.txt` for the output
-4. If `page.evaluate()` throws, the server falls back to `innerText()` — check the logs for `"htmlToMarkdown eval failed"` messages
-
-### Adding new API features
-
-The server returns OpenAI-compatible responses. If you're adding new fields or endpoints:
+### Adding Server Features
 
 - Follow the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) format
-- Add logging via `appendLog()` (writes to both console and `logs.txt`)
+- Log with `appendLog()` (writes to console + `logs.txt`)
 - Respect the `isGenerating` gate for anything that touches the browser
-- Return appropriate HTTP status codes and OpenAI-shaped error objects:
+- Return OpenAI-shaped errors:
   ```js
   res.status(400).json({
     error: { message: '...', type: 'invalid_request_error' }
   });
   ```
 
+### Working on the Dashboard
+
+The dashboard is a Next.js 16 app with:
+- **React 19** + Server Components
+- **shadcn/ui** for UI components
+- **Tailwind CSS v4**
+- **TypeScript**
+
+The dashboard connects to the adapter server via `lib/openadapter-client.ts`. The server URL is configured in `.env.local`:
+```
+NEXT_PUBLIC_OPENADAPTER_SERVER_URL=http://127.0.0.1:3001
+```
+
+### Modifying htmlToMd.js
+
+This function runs **inside Chromium**, not in Node.js:
+- No `require()`, no Node APIs, no external variables
+- Test by sending a real request and checking the response
+- If `page.evaluate()` throws, the server falls back to `innerText()`
+
 ## Testing
 
 ```bash
-npm run test:unit           # Unit tests only (no server needed)
-npm run test:integration    # Integration tests (requires running server)
-npm test                    # All tests
+pnpm test:unit             # Unit tests — fast, no server needed
+pnpm test:integration      # Integration tests — requires running server
+pnpm test                  # All tests
 ```
 
-Unit tests cover `extractPayload`, `htmlToMd`, and `rateLimiter` modules using Node's built-in test runner (`node:test`). Integration tests validate the HTTP endpoint against a live server.
+Unit tests use Node's built-in test runner (`node:test`) and cover `extractPayload`, `htmlToMd`, `rateLimiter`, and `toolCallParser` modules.
 
 To test manually:
-
 ```bash
-# Non-streaming request
-curl http://127.0.0.1:3000/v1/chat/completions \
+# Non-streaming
+curl http://127.0.0.1:3001/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"messages": [{"role": "user", "content": "Say hello"}]}'
+  -d '{"messages": [{"role": "user", "content": "Hello"}]}'
 
-# Streaming request
-curl http://127.0.0.1:3000/v1/chat/completions \
+# Streaming
+curl http://127.0.0.1:3001/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"messages": [{"role": "user", "content": "Say hello"}], "stream": true}'
-
-# CLI tool
-node adapter.js "Say hello"
+  -d '{"messages": [{"role": "user", "content": "Hello"}], "stream": true}'
 ```
-
-Check `logs.txt` for detailed request/response logs.
-
-## Areas for Contribution
-
-Check the [GitHub Issues](https://github.com/AviOfLagos/openAdapter/issues) for current tasks. Here are high-impact areas:
-
-- **Tool calling support** — the biggest gap; needed for OpenClaw skills, subagents, cron jobs, and MCP
-- **Selector updates** — keep selectors current when Claude's UI changes
-- **Better streaming** — replace DOM polling with MutationObserver or CDP event listeners for lower latency
-- **Conversation continuity** — maintain multi-turn conversations across API requests instead of starting fresh
-- **Config file** — move hardcoded values (port, timeouts, selectors) to a `.env` or config file
-- **Docker support** — containerize with Xvfb for running on servers without a display
-- **More tests** — browser-mocked tests for session recovery, DOM interaction, and streaming
 
 ## Style Guidelines
 
-- Use `const` / `let`, no `var`
-- Use `async/await` over raw promises
-- Log with `appendLog()` in server code, `console.error()` for status in the CLI tool
-- Keep functions focused — if adding significant logic, put it in a new file under `lib/`
-- Prefix log lines with `[moduleName]` for traceability (e.g., `[server]`, `[sessionManager]`)
+- **Modules:** CommonJS (`require` / `module.exports`)
+- **Variables:** `const` / `let`, never `var`
+- **Async:** `async/await` over raw promises
+- **Logging:** `appendLog()` in server, `console.error()` in CLI
+- **Functions:** Keep focused. New logic goes in a new file under `lib/`
+- **Log prefixes:** `[moduleName]` for traceability (e.g., `[server]`, `[sessionManager]`)
+- **Selectors:** Always in `SELECTOR_CHAINS`, never hardcoded inline
+
+## High-Impact Contribution Areas
+
+Check [Issues](https://github.com/AviOfLagos/openAdapter/issues) for current tasks. These are the areas where help has the biggest impact:
+
+| Area | Why It Matters | Difficulty |
+|------|---------------|------------|
+| **Tool calling** | Unlocks OpenClaw skills, subagents, MCP | Hard |
+| **Dashboard chat integration** | Wire chat tab to adapter instead of Vercel AI Gateway | Medium |
+| **Selector updates** | Keep the adapter working when Claude changes their UI | Easy |
+| **MutationObserver streaming** | Replace DOM polling for lower-latency streaming | Medium |
+| **Docker support** | Run on servers without a display (Xvfb) | Medium |
+| **Config file** | Move hardcoded values to `.env` / config | Easy |
+| **Unicode regex fix** | Rate limiter doesn't catch curly apostrophes | Easy |
+
+## First-Time Contributors
+
+Look for issues tagged [`good first issue`](https://github.com/AviOfLagos/openAdapter/labels/good%20first%20issue). These are scoped, well-documented, and a great way to get familiar with the codebase.
+
+Good first contributions:
+- Fix the Unicode regex in `rateLimiter.js` (Issue #2 in backlog)
+- Move a hardcoded config value to an environment variable
+- Add a missing unit test
+- Improve error messages
+- Update selectors when Claude changes their UI
+
+## Questions?
+
+- Open a [Discussion](https://github.com/AviOfLagos/openAdapter/discussions) for questions or ideas
+- File an [Issue](https://github.com/AviOfLagos/openAdapter/issues) for bugs or feature requests

--- a/README.md
+++ b/README.md
@@ -1,48 +1,39 @@
-# OpenAdapter - Claude.ai to OpenAI API Bridge for OpenClaw
+# OpenAdapter
 
-> **Self-hosted OpenAI-compatible API for Claude.ai** using Playwright automation. Perfect for [OpenClaw](https://github.com/openclaw/openclaw), custom AI assistants, and any tool expecting OpenAI's API format.
+> **Self-hosted OpenAI-compatible API for Claude.ai** — no API key required.
 
-**🦞 Built with OpenClaw in mind** — Use Claude's intelligence without API costs!
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Node.js 18+](https://img.shields.io/badge/Node.js-18%2B-green.svg)](https://nodejs.org)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-**No API key required** • **Free & Open Source** • **Streaming Support** • **File Uploads**
+OpenAdapter is a local server that bridges Claude's web interface into an **OpenAI-compatible REST API** using Playwright browser automation. It lets you use Claude with any tool that speaks the OpenAI chat completions format — [OpenClaw](https://github.com/openclaw/openclaw), [Continue.dev](https://continue.dev), custom scripts, IDE plugins, and more.
 
-A local server that bridges Claude's web interface (`claude.ai`) into an **OpenAI-compatible REST API**. Send requests to `http://127.0.0.1:3000/v1/chat/completions` and get responses back using your existing browser login session.
+**Free & Open Source** | **Streaming Support** | **File Uploads** | **Management Dashboard**
 
-Works with [OpenClaw](https://github.com/openclaw/openclaw), custom scripts, IDE plugins, and any tool that speaks the OpenAI chat completions format.
+---
 
-## 🦞 OpenClaw Integration
+## Project Status
 
-**Perfect for [OpenClaw](https://github.com/openclaw/openclaw) users!** Use Claude's intelligence with all your OpenClaw skills and automations - no API costs required.
+OpenAdapter is in active development. The core adapter server is **stable and functional**. A Next.js management dashboard is in progress.
 
-### Quick Setup for OpenClaw
+| Component | Status | Location |
+|-----------|--------|----------|
+| **Adapter Server** | Stable — 61 unit tests passing | `apps/server/` |
+| **CLI Tool** | Stable | `apps/server/src/adapter.js` |
+| **Management API** | Stable — 8 admin endpoints | `apps/server/src/lib/managementController.js` |
+| **Dashboard UI** | In progress — builds, monitoring tabs work, chat not yet wired to adapter | `apps/dashboard/` |
+| **Tool Calling** | Designed, implementation in progress | [feature/tool-calling branch](https://github.com/AviOfLagos/openAdapter/tree/feature/tool-calling) |
 
-```yaml
-# In your OpenClaw config:
-llm:
-  provider: openai
-  api_base: "http://127.0.0.1:3000/v1"
-  api_key: "dummy-key-not-used"
-  model: "claude-sonnet-4.5"
-  streaming: true
-```
+See the [Roadmap](docs/ROADMAP.md) for what's planned and where help is needed.
 
-**📖 [Complete OpenClaw Integration Guide](docs/OPENCLAW_INTEGRATION.md)**
-
-### Works With Any OpenAI-Compatible Tool
-
-- **[OpenClaw](https://github.com/openclaw/openclaw)** - Personal AI assistant with 100+ skills
-- **[Continue.dev](https://continue.dev)** - AI code assistant for VS Code
-- **Custom scripts** - Python, JavaScript, shell scripts
-- **IDE plugins** - Cursor and other OpenAI-compatible tools
-
-*Using OpenAdapter in your project? [Open a PR](https://github.com/AviOfLagos/openAdapter/pulls) to add it here!*
+---
 
 ## How It Works
 
 ```
 Your App / Client                  OpenAdapter                    claude.ai
 ─────────────────       ───────────────────────────────       ───────────────
-                           Express server (:3000)
+                           Express server (:3001)
   POST /v1/chat/    ──>   Receives OpenAI-format req    ──>   Types prompt
   completions              Manages Playwright browser          into chat UI
                            Polls DOM for response
@@ -52,93 +43,65 @@ Your App / Client                  OpenAdapter                    claude.ai
 
 1. Launches Chromium with a persistent profile (session stays logged in across restarts)
 2. Receives OpenAI-format chat completion requests over HTTP
-3. Extracts the user prompt and any file attachments (images, documents)
-4. Types the prompt into Claude's web UI and submits it
-5. Polls the DOM for the response, streaming chunks via SSE if requested
-6. Converts Claude's HTML response to clean Markdown
-7. Returns an OpenAI-compatible response (or SSE stream)
+3. Types the prompt into Claude's web UI and submits it
+4. Polls the DOM for the response, streaming chunks via SSE if requested
+5. Converts Claude's HTML response to clean Markdown
+6. Returns an OpenAI-compatible response
 
 ## Requirements
 
-- Node.js v18+
-- npm
-- A graphical desktop (the browser runs headful — no headless mode due to Cloudflare)
+- **Node.js v18+** and **pnpm** (monorepo uses pnpm workspaces)
+- A graphical desktop (the browser runs headful — Cloudflare blocks headless)
 
-## Setup
-
-### macOS
+## Quick Start
 
 ```bash
-git clone <repo-url> open-adapter
-cd open-adapter
-npm install
-npx playwright install chromium
+# Clone and install
+git clone https://github.com/AviOfLagos/openAdapter.git
+cd openAdapter
+pnpm install
+
+# Install Playwright's bundled Chromium
+cd apps/server && npx playwright install chromium && cd ../..
+# On Linux, also run: npx playwright install-deps chromium
+
+# Start both server and dashboard
+pnpm dev
 ```
 
-> Playwright downloads its own bundled Chromium — you don't need Chrome installed.
+On first run, a Chromium window opens to `claude.ai` — log in manually once. Your session persists in `.browser-profile/`.
 
-### Windows
+- **Server:** http://127.0.0.1:3001
+- **Dashboard:** http://localhost:3000
 
-```powershell
-git clone <repo-url> open-adapter
-cd open-adapter
-npm install
-npx playwright install chromium
-```
-
-> Use PowerShell or Windows Terminal. Command Prompt (`cmd`) works too but PowerShell is recommended.
-
-### Linux
+### Server Only
 
 ```bash
-git clone <repo-url> open-adapter
-cd open-adapter
-npm install
-npx playwright install chromium
-# Playwright may prompt you to install system dependencies:
-npx playwright install-deps chromium
+pnpm dev:server     # Start adapter server only (port 3001)
 ```
 
-> On Linux, Playwright needs certain system libraries (libnss3, libatk-bridge, etc.). The `install-deps` command installs them automatically (requires sudo).
-
-## First Run (Login)
-
-On the first run, the browser opens to `claude.ai`. You must log in manually once:
+### Test It
 
 ```bash
-node server.js
+curl http://127.0.0.1:3001/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "What is 2+2?"}]}'
 ```
-
-1. The browser opens to `claude.ai`
-2. Log in with your credentials
-3. Your session is saved in `.browser-profile/` and persists across restarts
-4. The server is now ready at `http://127.0.0.1:3000`
 
 ## Usage
 
-### Start the server
+### Non-streaming
 
 ```bash
-npm start        # Runs unit tests first, then starts the server (recommended)
-npm run dev      # Starts the server directly, skipping tests
-```
-
-The server listens on `http://127.0.0.1:3000`.
-
-### Send a request (non-streaming)
-
-```bash
-curl http://127.0.0.1:3000/v1/chat/completions \
+curl http://127.0.0.1:3001/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{
-    "messages": [{"role": "user", "content": "What is 2+2?"}]
-  }'
+  -d '{"messages": [{"role": "user", "content": "What is 2+2?"}]}'
 ```
 
-### Send a request (streaming)
+### Streaming (SSE)
 
 ```bash
-curl http://127.0.0.1:3000/v1/chat/completions \
+curl http://127.0.0.1:3001/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [{"role": "user", "content": "Explain recursion"}],
@@ -146,12 +109,10 @@ curl http://127.0.0.1:3000/v1/chat/completions \
   }'
 ```
 
-### Send images or files (base64)
-
-The adapter supports OpenAI's multimodal message format:
+### Images / Files (base64)
 
 ```bash
-curl http://127.0.0.1:3000/v1/chat/completions \
+curl http://127.0.0.1:3001/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [{
@@ -164,181 +125,88 @@ curl http://127.0.0.1:3000/v1/chat/completions \
   }'
 ```
 
-### CLI adapter (standalone)
-
-The original CLI tool is also available for one-off queries without running the server:
+### CLI Tool
 
 ```bash
-node adapter.js "What is 2+2?"
+node apps/server/src/adapter.js "What is 2+2?"
 ```
 
-Output goes to stdout. Status messages go to stderr, so you can pipe cleanly:
+### OpenClaw Integration
+
+```yaml
+# In your OpenClaw config:
+llm:
+  provider: openai
+  api_base: "http://127.0.0.1:3001/v1"
+  api_key: "dummy-key-not-used"
+  model: "claude-sonnet-4.5"
+  streaming: true
+```
+
+Works with any OpenAI-compatible tool: [OpenClaw](https://github.com/openclaw/openclaw), [Continue.dev](https://continue.dev), Cursor, custom scripts, etc.
+
+## Management API
+
+Monitor and control the server remotely:
 
 ```bash
-node adapter.js "List 5 prime numbers" | grep -i prime
+curl http://127.0.0.1:3001/admin/health        # Health + statistics
+curl http://127.0.0.1:3001/admin/status         # Simple status check
+curl -X POST http://127.0.0.1:3001/admin/session/restart  # Restart browser
+curl http://127.0.0.1:3001/admin/logs?lines=50  # Recent logs
 ```
 
-## Remote Management API
-
-OpenAdapter includes a comprehensive remote management API for monitoring and controlling the server:
-
-### Quick Examples
-
-```bash
-# Check server health
-curl http://127.0.0.1:3000/admin/health
-
-# Restart browser session
-curl -X POST http://127.0.0.1:3000/admin/session/restart
-
-# View recent logs
-curl http://127.0.0.1:3000/admin/logs?lines=50
-```
-
-### Available Endpoints
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/admin/health` | GET | Comprehensive health & statistics |
-| `/admin/status` | GET | Simple status check (healthy/degraded) |
-| `/admin/session/restart` | POST | Force browser restart |
-| `/admin/session/recover` | POST | Trigger multi-tier session recovery |
-| `/admin/session/new-chat` | POST | Start new conversation |
-| `/admin/logs` | GET | Retrieve recent logs |
-| `/admin/logs` | DELETE | Clear log file |
-| `/admin/config` | GET | View configuration |
-
-### Security (Optional)
-
-Enable API key authentication for remote access:
-
-```bash
-# Generate secure key
-export ADMIN_API_KEY="$(openssl rand -hex 32)"
-
-# Start server with authentication
-npm start
-
-# Use with requests
-curl -H "Authorization: Bearer your-key-here" \
-  http://127.0.0.1:3000/admin/health
-```
-
-**📖 [Complete Remote Management Guide](REMOTE_MANAGEMENT.md)**
+Optional API key auth: set `ADMIN_API_KEY` environment variable. See [REMOTE_MANAGEMENT.md](REMOTE_MANAGEMENT.md) for all 8 endpoints.
 
 ## Project Structure
 
 ```
-open-adapter/
-├── server.js               # Express API server (OpenAI-compatible endpoint)
-├── adapter.js              # Standalone CLI tool (single-prompt, exits after)
-├── lib/
-│   ├── sessionManager.js   # Browser lifecycle & multi-tier session recovery
-│   ├── extractPayload.js   # OpenAI message parser & file attachment handler
-│   ├── htmlToMd.js         # HTML-to-Markdown converter (runs in-browser)
-│   └── rateLimiter.js      # Detects Claude rate limits from DOM & response text
-├── tests/
-│   ├── unit/               # Unit tests (extractPayload, htmlToMd, rateLimiter)
-│   └── integration/        # Integration tests (HTTP endpoint validation)
-├── .browser-profile/       # Persistent Chromium session (created on first run)
-├── temp_uploads/           # Temporary directory for file attachments
-├── logs.txt                # Request/response logs (created at runtime)
-├── package.json
-└── README.md
+openAdapter/
+├── apps/
+│   ├── server/                  # Express adapter server (port 3001)
+│   │   ├── src/
+│   │   │   ├── server.js        # Main server + OpenAI endpoint
+│   │   │   ├── adapter.js       # Standalone CLI tool
+│   │   │   └── lib/
+│   │   │       ├── sessionManager.js       # Browser lifecycle + recovery
+│   │   │       ├── extractPayload.js       # OpenAI message parser
+│   │   │       ├── htmlToMd.js             # HTML→Markdown (runs in-browser)
+│   │   │       ├── rateLimiter.js          # Rate limit detection
+│   │   │       └── managementController.js # Admin API endpoints
+│   │   └── tests/
+│   │       ├── unit/            # 61 unit tests
+│   │       └── integration/     # HTTP endpoint tests
+│   │
+│   └── dashboard/               # Next.js management UI (port 3000)
+│       ├── app/                 # Routes (chat, activities, logs, settings)
+│       ├── components/          # React components + shadcn/ui
+│       └── lib/                 # API client, utilities
+│
+├── packages/                    # Shared packages (planned)
+├── turbo.json                   # Turborepo config
+├── pnpm-workspace.yaml          # Workspace definition
+└── docs/                        # Roadmap, strategy, backlog
 ```
-
-## Architecture
-
-### server.js — API Server
-
-The main entry point. An Express server that:
-
-- Accepts `POST /v1/chat/completions` in OpenAI chat format
-- Supports both regular JSON responses and SSE streaming (`"stream": true`)
-- Handles multimodal content: text, base64 images (`image_url`), and file attachments (`file_url`)
-- Deduplicates system context across requests (hashes system messages, only re-uploads when changed)
-- Converts large prompts (>15k chars) to file attachments automatically
-- Logs all requests and responses to `logs.txt`
-- Returns OpenAI-shaped responses with estimated token counts
-
-### lib/sessionManager.js — Browser Lifecycle
-
-Manages the Playwright browser with multi-tier recovery:
-
-| Level | Strategy | Description |
-|-------|----------|-------------|
-| L0 | `isPageAlive()` | Quick JS eval liveness probe |
-| L1 | `reloadPage()` | Reload the current page |
-| L2 | `newChat()` | Navigate to `claude.ai/new` (fresh conversation) |
-| L3 | `restartBrowser()` | Close browser context + relaunch Playwright |
-| L4 | Fatal | Return null, server responds with 503 |
-
-Sessions auto-timeout after 1 hour of inactivity, starting a fresh conversation.
-
-### lib/htmlToMd.js — HTML to Markdown
-
-A self-contained DOM-to-Markdown converter that runs inside the browser via `page.evaluate()`. Handles headings, bold/italic, code blocks (with language detection), tables, lists, checkboxes, links, images, blockquotes, and horizontal rules.
-
-### lib/rateLimiter.js — Rate Limit Detection
-
-Detects Claude's rate limiting by:
-1. Scanning the DOM for error/alert elements
-2. Pattern-matching the response text against known rate-limit phrases
-3. Parsing retry-after durations from the message
-
-Returns OpenAI-format `429` responses with `Retry-After` headers.
-
-### adapter.js — CLI Tool
-
-The original proof-of-concept. A standalone script that launches its own browser, sends a single prompt, captures the response, and exits. Useful for quick scripting without running the server.
-
-## Configuration
-
-### Server (server.js)
-
-| Variable | Default | Description |
-|---|---|---|
-| `PORT` | `3000` | Server listen port |
-| `MAX_TIMEOUT_MS` | `180000` (3 min) | Hard timeout waiting for Claude's response |
-| `STABLE_INTERVAL_MS` | `30000` (30 sec) | Content-unchanged = done threshold |
-| `POLL_MS` | `500` | DOM polling interval |
-| `SESSION_TIMEOUT_MS` | `3600000` (1 hr) | Inactivity before starting a new conversation |
-
-### CLI (adapter.js)
-
-| Variable | Default | Description |
-|---|---|---|
-| `CLAUDE_URL` | `https://claude.ai/new` | Starting URL |
-| `USER_DATA_DIR` | `.browser-profile/` | Persistent browser session directory |
-| `MAX_TIMEOUT_MS` | `120000` (2 min) | Hard timeout for response |
-| `STABLE_INTERVAL_MS` | `3000` (3 sec) | Content-unchanged = done threshold |
-| `POLL_MS` | `500` | Polling interval |
-
-## Selectors
-
-Both the server and CLI use fallback selector chains to find UI elements. If Claude updates their UI, edit `SELECTOR_CHAINS`:
-
-```
-promptInput:    div[contenteditable="true"] → div[role="textbox"] → ...
-sendButton:     button[aria-label*="Send"] → button[data-testid="send-button"]
-stopButton:     button[aria-label*="Stop"] → button[data-testid="stop-button"]
-responseBlocks: div[data-testid*="message"] → div.font-claude-response → ...
-fileInput:      input[type="file"]
-```
-
-To inspect current selectors, open `claude.ai` in Chrome DevTools (F12) and inspect the elements.
 
 ## Testing
 
 ```bash
-npm test              # Run all tests (unit + integration)
-npm run test:unit     # Unit tests only (no server needed)
-npm run test:integration  # Integration tests (requires running server)
+pnpm test:unit          # Unit tests (no server needed) — fast
+pnpm test               # All tests
+pnpm dev:server         # Then in another terminal:
+pnpm test:integration   # Integration tests against live server
 ```
 
-Unit tests cover the core modules (`extractPayload`, `htmlToMd`, `rateLimiter`) and run automatically before the server starts when using `npm start`.
+## Configuration
 
-Integration tests validate the HTTP endpoint (request validation, CORS, response shape) against a live server.
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `3001` | Server listen port |
+| `MAX_TIMEOUT_MS` | `180000` (3 min) | Hard timeout for Claude's response |
+| `STABLE_INTERVAL_MS` | `30000` (30 sec) | Content-unchanged = done threshold |
+| `POLL_MS` | `500` | DOM polling interval |
+| `SESSION_TIMEOUT_MS` | `3600000` (1 hr) | Inactivity before new conversation |
+| `ADMIN_API_KEY` | none | Optional API key for management endpoints |
 
 ## Limitations
 
@@ -346,7 +214,6 @@ Integration tests validate the HTTP endpoint (request validation, CORS, response
 - **Single request at a time** — concurrent requests return 429 (busy)
 - **No login automation** — you log in manually once; session persists in `.browser-profile/`
 - **Selectors may break** — Claude UI updates can change the DOM structure
-- **No conversation memory** — each server session timeout starts a fresh chat
 - **Token counts are estimates** — calculated from character length, not actual tokenization
 
 ## Troubleshooting
@@ -357,34 +224,37 @@ Integration tests validate the HTTP endpoint (request validation, CORS, response
 | Cloudflare challenge page | Must run headful (default). Don't set `headless: true` |
 | Login not persisting | Ensure `.browser-profile/` exists and isn't being deleted |
 | Timeout with no response | Increase `MAX_TIMEOUT_MS` or check if Claude is down |
-| Browser doesn't open | Run `npx playwright install chromium` |
-| 503 session recovery failed | All recovery tiers failed. Restart `node server.js` |
-| 429 rate limit | Claude's free/pro message limit hit. Wait for the retry-after period |
-| **Linux:** missing shared libraries | Run `npx playwright install-deps chromium` to install system dependencies |
-| **Linux:** no display / `DISPLAY not set` | You need a graphical desktop. For headless servers, use Xvfb: `xvfb-run node server.js` |
-| **Windows:** `npx` not recognized | Ensure Node.js is in your PATH. Reinstall Node.js using the official installer and check "Add to PATH" |
-| **macOS:** Chromium blocked by Gatekeeper | Go to System Settings > Privacy & Security and click "Allow Anyway" for the Chromium binary |
+| Browser doesn't open | Run `npx playwright install chromium` in `apps/server/` |
+| 503 session recovery failed | All recovery tiers failed. Restart the server |
+| 429 rate limit | Claude's message limit hit. Wait for the retry-after period |
+| Dashboard can't connect | Check server is running on port 3001 |
+| **Linux:** missing shared libraries | Run `npx playwright install-deps chromium` |
+| **Linux:** no display | You need a graphical desktop. For headless servers: `xvfb-run node server.js` |
 
 ## Contributing
 
-We welcome contributions! OpenAdapter is built with the OpenClaw community in mind. 🦞
+We welcome contributions! OpenAdapter is an open project and we want to make it easy for anyone to help improve it.
 
-### Good First Issues
-Check out issues labeled [`good first issue`](https://github.com/AviOfLagos/openAdapter/labels/good%20first%20issue) - these are perfect for newcomers!
+### Where to Start
 
-### Priority Features
-- **🎯 Tool Calling Support (v1.2)** - #1 requested feature for OpenClaw integration
-- Docker support
-- Better streaming (MutationObserver)
-- Configuration file
+1. Check [Issues](https://github.com/AviOfLagos/openAdapter/issues) for open tasks
+2. Look for [`good first issue`](https://github.com/AviOfLagos/openAdapter/labels/good%20first%20issue) labels
+3. Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide
+4. See the [Roadmap](docs/ROADMAP.md) for the big picture
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide and [roadmap](docs/roadmap-milestones.md) for planned features.
+### High-Impact Areas
+
+- **Tool calling support** — the biggest gap; needed for OpenClaw skills, subagents, and MCP
+- **Dashboard chat integration** — wire the dashboard's chat tab to OpenAdapter instead of Vercel AI Gateway
+- **Selector updates** — keep selectors current when Claude changes their UI
+- **Better streaming** — replace DOM polling with MutationObserver
+- **Docker support** — containerize with Xvfb for headless server environments
 
 ### Community
-- 💬 [Discussions](https://github.com/AviOfLagos/openAdapter/discussions) - Ask questions, share workflows
-- 🐛 [Issues](https://github.com/AviOfLagos/openAdapter/issues) - Bug reports and feature requests
-- 🦞 [OpenClaw Integration](https://github.com/AviOfLagos/openAdapter/discussions/categories/openclaw-integration) - OpenClaw-specific help
+
+- [Discussions](https://github.com/AviOfLagos/openAdapter/discussions) — questions, ideas, workflows
+- [Issues](https://github.com/AviOfLagos/openAdapter/issues) — bugs and feature requests
 
 ## License
 
-ISC
+[MIT](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in OpenAdapter, please report it responsibly.
+
+**Do NOT open a public issue for security vulnerabilities.**
+
+Instead, use one of these methods:
+
+1. **GitHub Security Advisory** (preferred): Go to the [Security tab](https://github.com/AviOfLagos/openAdapter/security/advisories/new) and create a private advisory.
+2. **Email:** Contact the maintainers directly via their GitHub profile.
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if you have one)
+
+### Response Timeline
+
+- **Acknowledgment:** Within 72 hours
+- **Assessment:** Within 1 week
+- **Fix/Disclosure:** Depends on severity, but we aim for 30 days
+
+## Security Considerations
+
+OpenAdapter has some inherent security properties to be aware of:
+
+- **Browser session:** `.browser-profile/` contains your Claude login session. Never commit or share this directory.
+- **Management API:** The `/admin/*` endpoints can restart sessions and clear logs. Set `ADMIN_API_KEY` if exposing beyond localhost.
+- **No authentication by default:** The chat completions endpoint has no auth. It's designed for local use only. Do not expose to the public internet without adding authentication.
+- **Temp files:** `temp_uploads/` may contain uploaded files. These are cleaned up but could briefly contain sensitive data.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest on `main` | Yes |
+| Feature branches | Best effort |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,75 @@
+# OpenAdapter Roadmap
+
+This roadmap shows what's been done, what's in progress, and what's planned. Contributions welcome at every phase.
+
+## Phase 1: Foundation — Complete
+
+- [x] Express server with OpenAI-compatible `/v1/chat/completions` endpoint
+- [x] Playwright browser automation with persistent session
+- [x] SSE streaming support
+- [x] Multi-tier session recovery (L0-L4)
+- [x] HTML-to-Markdown conversion
+- [x] Rate limit detection
+- [x] Base64 image/file upload support
+- [x] System context deduplication
+- [x] Standalone CLI adapter
+- [x] Unit test suite (61 tests passing)
+- [ ] Fix Unicode regex bug in rate limiter
+- [ ] Extract shared DOM helpers from server.js/adapter.js
+- [ ] Move config to environment variables / `.env` file
+
+## Phase 2: Tool Calling — In Progress
+
+Design complete, implementation on `feature/tool-calling` branch.
+
+- [x] Tool call parser module (`toolCallParser.js`)
+- [x] File-based tool definition injection (avoids inline prompt manipulation)
+- [x] Tool call response formatting (OpenAI-compatible `tool_calls` array)
+- [x] Streaming tool call deltas (`delta.tool_calls`)
+- [x] Unit tests for tool parsing (40+ tests)
+- [ ] End-to-end testing with real Claude responses
+- [ ] Multi-turn tool calling conversations
+- [ ] Handle `role: "tool"` messages in input
+
+## Phase 3: Monorepo + Dashboard — In Progress
+
+Monorepo migration complete, dashboard UI built, integration pending.
+
+- [x] Turborepo + pnpm workspace setup
+- [x] Server migrated to `apps/server/` (port 3001)
+- [x] Remote management API (8 admin endpoints)
+- [x] Next.js 16 dashboard with 4-tab interface
+- [x] Server Activities monitoring (real-time health, stats)
+- [x] Log viewer (search, filter, download)
+- [x] Settings panel (session controls)
+- [ ] **Wire dashboard chat to OpenAdapter** (currently uses Vercel AI Gateway)
+- [ ] End-to-end testing of dashboard + server
+- [ ] Mobile responsive polish
+
+## Phase 4: Full OpenClaw Compatibility — Planned
+
+Depends on Phase 2 (tool calling).
+
+- [ ] Skills execution via tool calling
+- [ ] Subagent spawning support
+- [ ] Cron job management
+- [ ] File/shell operations
+- [ ] MCP server tool integration
+- [ ] Multi-turn conversation context preservation
+
+## Phase 5: DevOps & Scale — Planned
+
+- [ ] Docker support with Xvfb (headless server deployment)
+- [ ] Replace DOM polling with MutationObserver
+- [ ] Multi-tab concurrency for parallel requests
+- [ ] GitHub Actions CI improvements
+- [ ] Deployment guide (VPS, Docker, Vercel for dashboard)
+
+---
+
+## How to Contribute to the Roadmap
+
+1. Pick an unchecked item from any phase
+2. Check [Issues](https://github.com/AviOfLagos/openAdapter/issues) to see if someone's already working on it
+3. If not, open an issue to claim it and start a PR
+4. Items marked "Planned" are open for design discussion — feel free to propose approaches

--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "openadapter-monorepo",
   "version": "1.0.0",
   "private": true,
-  "description": "OpenAdapter monorepo - Claude.ai to OpenAI API Bridge with AI-powered dashboard",
+  "license": "MIT",
+  "description": "Self-hosted OpenAI-compatible API bridge for Claude.ai via Playwright, with a Next.js management dashboard.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AviOfLagos/openAdapter.git"
+  },
+  "homepage": "https://github.com/AviOfLagos/openAdapter",
+  "bugs": {
+    "url": "https://github.com/AviOfLagos/openAdapter/issues"
+  },
   "scripts": {
     "dev": "turbo run dev --parallel",
     "dev:server": "turbo run dev --filter=@openadapter/server",


### PR DESCRIPTION
## Summary

Prepares the project for community contributions during periods of reduced maintainer activity. After this PR, contributors have everything they need to understand, set up, and contribute to OpenAdapter without maintainer hand-holding.

- **README.md** — Full rewrite: project status table showing what works/what's in progress, monorepo quick start (pnpm, port 3001), clear contributor onboarding section
- **CONTRIBUTING.md** — Rewritten for monorepo workflow: pnpm commands, Turborepo structure, both apps documented, first-time contributor section with difficulty-rated contribution areas
- **ROADMAP.md** — Updated with actual current status across all 5 phases, checkboxes showing what's done vs pending, "how to contribute" section
- **CLAUDE.md** — Updated for monorepo architecture, both apps, correct paths and ports
- **CODE_OF_CONDUCT.md** — New: Contributor Covenant v2.1
- **SECURITY.md** — New: vulnerability reporting policy, security considerations
- **.github/CODEOWNERS** — New: PR review routing to @AviOfLagos
- **package.json** — Added MIT license, repository/homepage/bugs URLs
- **.gitignore** — Fixed: docs/ was being ignored but contains tracked files (roadmap, backlog)

## What This Enables

After merging, a new contributor can:
1. Read the README to understand what OpenAdapter is and what's working
2. Check the Roadmap to find something to work on
3. Follow CONTRIBUTING.md to set up their dev environment
4. Pick from the difficulty-rated contribution areas table
5. Open a PR with CODEOWNERS auto-requesting review
6. Report security issues privately via SECURITY.md

## Test plan
- [x] All files render correctly in GitHub markdown preview
- [x] Links between docs are consistent (CONTRIBUTING.md ↔ README ↔ ROADMAP)
- [x] Port references updated to 3001 throughout
- [x] Monorepo commands (pnpm) used consistently
- [ ] Verify CODEOWNERS triggers review requests on a test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)